### PR TITLE
Remove translator name line from translation display

### DIFF
--- a/src/components/AyahCard.jsx
+++ b/src/components/AyahCard.jsx
@@ -68,7 +68,6 @@ const AyahCard = ({ verse, surahNumber }) => {
     (bookmark) => bookmark.surahNumber === surahNumber && bookmark.ayahNumber === verse.verse_number
   );
   const translationMeta = verse.translations && verse.translations[0] ? verse.translations[0] : null;
-  const translationLabel = translationMeta?.label || translationMeta?.language || language;
 
   const handlePlayAudio = () => {
     if (isPlaying && !isPaused) {
@@ -137,9 +136,6 @@ const AyahCard = ({ verse, surahNumber }) => {
 
         {translationMeta && (
           <div className={`english-text p-4 rounded-lg ${accentBgStyle}`}>
-            <p className={`text-sm font-medium mb-2 ${secondaryTextStyle}`}>
-              Translation{translationLabel ? ` (${translationLabel})` : ''}:
-            </p>
             <p className={textStyle}>{translationMeta.text}</p>
           </div>
         )}


### PR DESCRIPTION
This removes the line above translations that displayed the translator's name (e.g., "Translation (Sahih International):"). Now only the translation text is shown without the translator label.